### PR TITLE
Add epic issue: Feature — Subjects (CLI)

### DIFF
--- a/issues/feature-subjects-cli.md
+++ b/issues/feature-subjects-cli.md
@@ -1,0 +1,43 @@
+# Feature: Subjects (CLI)
+
+## Summary
+Build CLI support for managing subjects beyond creation: list, rename, and delete.
+
+## Subfeature issues
+- [ ] [Subjects: List subjects (CLI)](subjects-list-subjects-cli.md)
+- [ ] [Subjects: Rename subject (CLI)](subjects-rename-subject-cli.md)
+- [ ] [Subjects: Delete subject (CLI)](subjects-delete-subject-cli.md)
+
+## Command examples
+```bash
+$ trak subject list
+```
+Expected output snippet:
+```
+Subjects:
+- Swift
+- Cybersecurity
+- Systems Design
+```
+
+```bash
+$ trak subject rename "Swift" "SwiftUI"
+```
+Expected output snippet:
+```
+Renamed subject "Swift" -> "SwiftUI".
+```
+
+```bash
+$ trak subject delete "Cybersecurity"
+```
+Expected output snippet:
+```
+Deleted subject "Cybersecurity".
+```
+
+## Error handling (exit codes/messages)
+- Exit code `1`: Invalid arguments or missing required subject name(s). Message: `Invalid arguments. See --help for usage.`
+- Exit code `2`: Subject not found. Message: `Subject "<name>" not found.`
+- Exit code `3`: Target subject already exists (rename). Message: `Subject "<name>" already exists.`
+- Exit code `4`: Storage or filesystem error. Message: `Failed to update subjects: <details>`


### PR DESCRIPTION
### Motivation
- Introduce a single epic to track CLI work for subject management (list, rename, delete) that extends existing subject creation functionality.
- Consolidate the remaining subject-related subfeatures into a checklist to clarify scope and priorities.
- Provide concrete example commands and expected output to guide implementation and user-facing behavior.
- Define error handling exit codes and messages to standardize failure modes across the new commands.

### Description
- Add `issues/feature-subjects-cli.md` containing the epic summary, a checklist linking to the three subfeature issues, command examples, and expected output snippets.
- Document explicit exit codes and messages for invalid arguments, subject-not-found, target-exists (rename), and storage errors.
- Include example commands: `trak subject list`, `trak subject rename "Old" "New"`, and `trak subject delete "Name"` with expected outputs.
- Commit the new markdown file to the repository to make the epic available to contributors.

### Testing
- No automated tests were run because this change only adds documentation.
- The new file was created and committed successfully in the repository.
- N/A for unit or integration tests due to documentation-only change.
- N/A

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e972095788330ae6af2a70cf0b18e)